### PR TITLE
Fix _on_room_disconnected bug

### DIFF
--- a/livekit-agents/livekit/agents/ipc/proc_main.py
+++ b/livekit-agents/livekit/agents/ipc/proc_main.py
@@ -62,7 +62,7 @@ def _start_job(
     request_shutdown_fut = asyncio.Future[_ShutdownInfo]()
 
     @room.on("disconnected")
-    def _on_room_disconnected():
+    def _on_room_disconnected(*args):
         with contextlib.suppress(asyncio.InvalidStateError):
             request_shutdown_fut.set_result(
                 _ShutdownInfo(user_initiated=False, reason="room disconnected")


### PR DESCRIPTION
Bringing in this [pull request](https://github.com/livekit/agents/pull/668) which was causing issues where our room agents shutdown hooks weren't being received bc they were hitting an error, which lead to all room agents taking the maximum amount of time to drain.

For the record, I don't think it's expected that these tests pass on this fork and they also didn't pass on their PR which I linked.